### PR TITLE
Add `type="button"` to buttons, to prevent submission of parent form

### DIFF
--- a/src/VPaginator.vue
+++ b/src/VPaginator.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="v-paginator">
-    <button :class="config.classes_prev" @click="fetchData(prev_page_url)" :disabled="!prev_page_url">
+    <button type="button" :class="config.classes_prev" @click="fetchData(prev_page_url)" :disabled="!prev_page_url">
       {{config.previous_button_text}}
     </button>
     <span>Page {{current_page}} of {{last_page}}</span>
-    <button :class="config.classes_next" @click="fetchData(next_page_url)" :disabled="!next_page_url">
+    <button type="button" :class="config.classes_next" @click="fetchData(next_page_url)" :disabled="!next_page_url">
       {{config.next_button_text}}
     </button>
   </div>


### PR DESCRIPTION
Due to no `type` attributes on the pagination buttons, the browser renders them as `type="submit"`, which would submit a parent form if one is wrapped around the pagination.

Adding `type="button"` attributes to each button prevents this from happening.